### PR TITLE
Update tlsnotary discord link

### DIFF
--- a/src/data/Projects.json
+++ b/src/data/Projects.json
@@ -175,7 +175,7 @@
         "github": "https://github.com/tlsnotary/tlsn"
       },
       {
-        "discord": "https://discord.gg/EjpvcEaqkh"
+        "discord": "https://discord.gg/9XwESXtcN7"
       }
     ]
   }


### PR DESCRIPTION
Realized that the link I added previously is ephemeral, here is a new one.