### PR TITLE
change: Update website and github for ZKEVM

### DIFF
--- a/src/data/Projects.json
+++ b/src/data/Projects.json
@@ -31,10 +31,10 @@
     "description": "A zk-rollup that can generate zk proofs for general EVM verification. This allows us to build a fully EVM-compatible zk-Rollup, which any existing Ethereum application can easily migrate to.",
     "links": [
       {
-        "website": "https://hackmd.io/@yezhang/S1_KMMbGt"
+        "website": "https://privacy-scaling-explorations.github.io/zkevm-docs/"
       },
       {
-        "github": "https://github.com/appliedzkp/zkevm-specs"
+        "github": "https://github.com/appliedzkp/zkevm-circuits"
       }
     ]
   },


### PR DESCRIPTION
Changed the github page to point to `zkevm-circuits` instead of specs.
Changed the website page to point to the MDBook that we have under construction. (Should become the reference page in the future for documentation about the project).